### PR TITLE
added validation for null summary posts

### DIFF
--- a/src/main/java/org/fenixedu/learning/servlets/FenixEduLearningContextListener.java
+++ b/src/main/java/org/fenixedu/learning/servlets/FenixEduLearningContextListener.java
@@ -54,8 +54,10 @@ public class FenixEduLearningContextListener implements ServletContextListener {
         });
         FenixFramework.getDomainModel().registerDeletionListener(Summary.class, (summary) -> {
             Post post = summary.getPost();
-            summary.setPost(null);
-            post.delete();
+            if(post!=null) {
+                summary.setPost(null);
+                post.delete();
+            }
         });
         Signal.register(Summary.EDIT_SIGNAL, (DomainObjectEvent<Summary> event) -> {
             SummaryListener.updatePost(event.getInstance().getPost(), event.getInstance());


### PR DESCRIPTION
The system assumed that every summary have a post. This is not true for all summaries so we need to validate it first.
