### PR TITLE
bugfix: creation of empty annoucements for evaluation marks

### DIFF
--- a/src/main/java/org/fenixedu/learning/servlets/FenixEduLearningContextListener.java
+++ b/src/main/java/org/fenixedu/learning/servlets/FenixEduLearningContextListener.java
@@ -76,7 +76,8 @@ public class FenixEduLearningContextListener implements ServletContextListener {
     }
 
     private static void handleMarksPublishment(MarkPublishingBean bean) {
-        if (!Strings.isNullOrEmpty(bean.getEvaluation().getPublishmentMessage()) && bean.getCourse().getSite() != null) {
+        String publishmentMessage = bean.getEvaluation().getPublishmentMessage();
+        if (publishmentMessage != null && !Strings.isNullOrEmpty(publishmentMessage.trim()) && bean.getCourse().getSite() != null) {
             Category cat = bean.getCourse().getSite().categoryForSlug("announcement");
             if (cat != null) {
                 Post post = new Post(bean.getCourse().getSite());


### PR DESCRIPTION
when an evaluation was published with an empty message the system created an announcement with an empty message.
- added validation for the case of empty messages with space characters
- if the message is empty we don't create an announcement.
